### PR TITLE
build/install/docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-lin
 RUN apt-get -qq update && apt-get -qq install fontconfig
 RUN ln -s /opt/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/
 RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' -e 's/security.debian.org/archive.debian.org/g' -e '/stretch-updates/d' /etc/apt/sources.list
-RUN sed -ri '/policy.*name="height"/s/value="([^"]*)"/value="32KP"/' /etc/ImageMagick-6/policy.xml
+RUN sed -ri '/policy.*name="height"/s/value="([^"]*)"/value="40KP"/' /etc/ImageMagick-6/policy.xml
 
 WORKDIR /app
 ADD Gemfile* /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /opt
 RUN curl -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar -jxf -
 RUN apt-get -qq update && apt-get -qq install fontconfig
 RUN ln -s /opt/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' -e 's/security.debian.org/archive.debian.org/g' -e '/stretch-updates/d' /etc/apt/sources.list
 RUN sed -ri '/policy.*name="height"/s/value="([^"]*)"/value="32KP"/' /etc/ImageMagick-6/policy.xml
 
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 gem 'rails'
 gem 'pg'
 gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
-gem 'coffee-rails', '~> 4.1.0'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,13 +65,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cliver (0.3.2)
-    coffee-rails (4.1.1)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.1.x)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     cucumber (7.0.0)
@@ -132,7 +125,6 @@ GEM
       fog-aws
     erubis (2.7.0)
     excon (0.85.0)
-    execjs (2.8.1)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     ffi (1.15.4)
@@ -187,7 +179,6 @@ GEM
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
     libv8 (3.16.14.19)
-    libv8 (3.16.14.19-x86_64-linux)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -198,12 +189,16 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0901)
     mini_mime (1.1.1)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
     nested_form (0.3.2)
     netrc (0.11.0)
     nio4r (2.5.8)
+    nokogiri (1.12.4)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.4-x86_64-linux)
@@ -339,8 +334,6 @@ GEM
     tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
@@ -357,13 +350,13 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
   byebug
   capybara
-  coffee-rails (~> 4.1.0)
   cucumber-rails
   database_cleaner
   dragonfly (~> 1.4.0)
@@ -388,7 +381,6 @@ DEPENDENCIES
   spring
   sqlite3 (~> 1.3.6)
   therubyracer
-  uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,16 +10,19 @@ services:
     environment:
       - RAILS_ENV=production
       - RAILS_SERVE_STATIC_FILES=true
+      - BUNDLE_APP_CONFIG=/app/.bundle
+      - BUNDLE_PATH=vendor/bundle
       - RAILS_LOG_TO_STDOUT=true
       - DATABASE_URL=postgresql://postgres@db/spectre
       - DATABASE_USERNAME=
       - POSTGRES_PASSWORD=somepassword
       - DOMAIN_NAME=app
-      - PORT=:3000
+      - PORT=3000
       - PROTOCOL=http://
     volumes:
+      # You may need to use an absolute path
       - .:/app
-    command: bash -c "rm -f /app/tmp/pids/*.pid && rake assets:precompile && SECRET_KEY_BASE=`rake secret` rails server -p 3000"
+    command: bash -c "rm -f /app/tmp/pids/*.pid && bundle exec rake assets:precompile && SECRET_KEY_BASE=`bundle exec rake secret` bundle exec rails server -p 3000"
 
   db:
     image: postgres:9.6


### PR DESCRIPTION
- Lighten dependencies: coffee-rails
... requires coffee-scripts
... requires uglifier
... requires execjs
... requires a valid JS interpreter
... which is likely unavailable (at least from within Docker)

... all of this just to compress some (quite limited) javascript. Requiring a frontend compiler at run-time is inadequate, let's drop it.

- Also, newer version of `bundle` doesn't consider local package by default (default is in /usr/...) which make container "forget" their installation. Ensure a local configuration is used and enforce local `rake` version by prefixing ruby commands by `bundle exec`.

- puma PORT was wrongly prefixed by an extra ":"

- Added a note about using relative path in the docker-compose's service's `volume` definition.
